### PR TITLE
DeleteAuthImprovement

### DIFF
--- a/app_Backend/backend_server/urls.py
+++ b/app_Backend/backend_server/urls.py
@@ -55,8 +55,8 @@ urlpatterns = [
                   path('save_ta_message/', views.terminate_account_message_create, name='ta_message_create'),
                   # saver terminate acc message
                   path('login/', views.login_view, name='login'),
-                  path('user/authenticate/<str:email>/', views.auth_password, name='auth_password'),
-                  path('user/delete/<str:email>/', views.delete_user, name='delete_user'),
+                  path('user/authenticate/', views.auth_password, name='auth_password'),
+                  path('user/delete/<str:userId>/', views.delete_user, name='delete_user'),
                   path('setworkout/', views.set_workout, name='setworkout'),
                   path('workoutdata/', views.wrk_data, name='workoutdata'),
                   path('login-sm/', views.social_media_login, name='login-sm'),

--- a/app_Backend/backend_server/views.py
+++ b/app_Backend/backend_server/views.py
@@ -212,15 +212,17 @@ def login_view(request):
         except MyUser.DoesNotExist:
             return Response({'message': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
 
-@api_view(['GET'])
+@api_view(['POST']) #changed to post for more secure authorization
 @csrf_exempt
-def auth_password(request, email, format=None):
-    if request.method == 'GET':
-        user_password = request.GET.get('password')
-        print('pass:' + user_password)
+def auth_password(request, format=None):
+    if request.method == 'POST': 
+        userId = request.data.get('userId')
+        password = request.data.get('password')
+
+        print(f'userId: {userId}, password: {password}') #debug
         try:
-            user = MyUser.objects.get(pk=email) 
-            if user.password == user_password:
+            user = MyUser.objects.get(id=userId) 
+            if user.password == password: 
                 return Response(status=status.HTTP_200_OK)
             else:
                 return Response(status=status.HTTP_403_FORBIDDEN)
@@ -229,17 +231,21 @@ def auth_password(request, email, format=None):
     else:
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-@api_view(['DELETE'])
+@api_view(['DELETE']) #replaced email with userID for more security
 @csrf_exempt
-def delete_user(request, email):
-    print('email received:' + email)
+def delete_user(request, userId):
+    print('userId received:' + userId)
+
     if request.method == 'DELETE':
         try:
-            user = MyUser.objects.get(pk=email)
+            user = MyUser.objects.get(id=userId)
             user.delete()
             return JsonResponse({"message": "User deleted successfully"}, status=status.HTTP_204_NO_CONTENT)
         except MyUser.DoesNotExist:
             return JsonResponse({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    else:  
+        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 def get_all_details(request):
     if request.method == 'POST':


### PR DESCRIPTION
Slight improvement to security by taking email and password out of the URLs of endpoints. Fixes the issue of passwords being potentially cut-off due to special characters. More work to be done on security in general, but solves immediate issues.

BACKEND:
- Replace URL user/authenticate/<str:email>/ with user/authenticate/
- View auth_password now POST type
- Replace user/delete/<str:email>/ with user/delete/<str:userId>/

FRONTEND: terminate_account.dart
- Replace call to '$baseURL/user/authenticate/$userEmail/?password=$enteredPassword' with '$baseURL/user/authenticate/',
- Replace '$baseURL/user/delete/$userEmail/' with '$baseURL/user/delete/$userId/'
- find id instead of email from userDetails model

[Postman Test of previous version](https://github.com/user-attachments/files/19524564/OriginalEndpointsTest.postman_test_run.json)
[Updated Endpoints Postman Test](https://github.com/user-attachments/files/19524565/UpdatedEndpointsTest.postman_test_run.json)

