### PR TITLE
Database Password Hashing

### DIFF
--- a/app_Backend/.env.example
+++ b/app_Backend/.env.example
@@ -1,0 +1,4 @@
+SECRET_KEY= your-secret-key-here 
+EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend'
+DEFAULT_FROM_EMAIL=your@email.here
+DEBUG = TRUE


### PR DESCRIPTION
### Summary:
Uses the default Django implementation of password hashing into the backend. This improves security by forcing the database to store hashed passwords, not plaintext. In the event of a data breach, the users' actual passwords are not known. This uses salted PBKDF2 by default but can be overridden globally in Django's settings.py if needed.

This does not touch any of the models, but instead adds a hashing component to the serializers. Thus should integrate seemlessly into the MongoDB update. Received plaintext passwords will be hashed before being sent to the database. Updated passwords will also be hashed.

### Affected Files:
**app_Backend/backend_server/views.py:**
- imported Django password checker and maker for password hashing and comparison
- login_view (standard login handler) now uses Django's check_password() function to compare received password to hashed
- auth_password (delete authorization handler)  now uses Django's check_password() function to compare received password to hashed
- password_reset_new_password (password reset handler) now hashes the received password using Django's make_password() function

**app_Backend/backend_server/serializers.py:**
- UserSerializer (MyUser model handler) overridden create() method to hash the received password and added an env DEBUG toggle to disable password field being returned with model
- SocialMediaUserSerializer (SM model handler) overridden create() method to hash the received password and added an env DEBUG toggle to disable password field being returned with model

**app_Backend/backend_server/.env.example**
- added a new example .env file for convenience and demonstration

### Testing Results:
(uses same testing suite from previous commit as that tests account creation, login, password updates)
[PasswordHashingTest.postman_test_run.json](https://github.com/user-attachments/files/19928269/PasswordHashingTest.postman_test_run.json)
