### PR TITLE
ID Unifier Base Commit

### DIFF
--- a/app_Backend/backend_server/models.py
+++ b/app_Backend/backend_server/models.py
@@ -11,20 +11,22 @@ from datetime import datetime, timedelta
 #   TODO:   - set password max length to 20 in Flutter
 #           - used in Flutter in signup.dart
 class MyUser(Document):
-    id = IntField(primary_key=True, binary=False)  # Explicit ID field (can be UUID, etc.)
+    id = UUIDField(primary_key=True, default=uuid.uuid4, binary=False)  # Explicit ID field (was int, now UUIDv4)
     email = StringField(required=True)
     username = StringField(required=True, unique=True)
     password = StringField(required=True)
     user_created = DateTimeField(default=datetime.utcnow)
-    login_type = StringField(default='')
-    login_id = StringField(unique=True, required=False, sparse=True, default='') #added sparse to ensure nulls don't clash in MongoDB
-    otp = StringField(default='')
+    login_type = StringField(required=False, sparse=True, default=None)
+    login_id = StringField(unique=True, required=False, sparse=True, default=None) #added sparse to ensure nulls don't clash in MongoDB
+    otp = StringField(default=None)
     otp_created_at = DateTimeField()
 
     # generate the id, starting at 1000, and add 1 to each new user
     def save(self, *args, **kwargs):
         self.email = self.email.strip().lower() ##lowercase email
+
         #old ID system
+        '''        
         if not self.id:  # If id is not already set
             last_user = MyUser.objects.order_by('-id').first()
             if last_user:
@@ -32,6 +34,7 @@ class MyUser(Document):
             else:
                 last_id = 999  # Starting from 1000
             self.id = str(last_id + 1)  # Increment the id
+            '''
     
         super(MyUser, self).save(*args, **kwargs)
 

--- a/app_Backend/backend_server/postman/collections/TestingSuite.postman_collection.json
+++ b/app_Backend/backend_server/postman/collections/TestingSuite.postman_collection.json
@@ -52,6 +52,11 @@
 					"mode": "formdata",
 					"formdata": [
 						{
+							"key": "id",
+							"value": "374669d8-4fd5-4d6c-8cbb-107c9f229290",
+							"type": "text"
+						},
+						{
 							"key": "email",
 							"value": "TEST@test.com",
 							"type": "text"
@@ -119,6 +124,11 @@
 				"body": {
 					"mode": "formdata",
 					"formdata": [
+						{
+							"key": "id",
+							"value": "57544e52-e6dc-4fc9-af33-c80ee567f16e",
+							"type": "text"
+						},
 						{
 							"key": "email",
 							"value": "test2@test.com",
@@ -268,13 +278,13 @@
 					"urlencoded": []
 				},
 				"url": {
-					"raw": "{{api_url_base}}/update/1000/",
+					"raw": "{{api_url_base}}/update/374669d8-4fd5-4d6c-8cbb-107c9f229290/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"update",
-						"1000",
+						"374669d8-4fd5-4d6c-8cbb-107c9f229290",
 						""
 					]
 				}
@@ -348,13 +358,13 @@
 					]
 				},
 				"url": {
-					"raw": "{{api_url_base}}/update/1000/",
+					"raw": "{{api_url_base}}/update/374669d8-4fd5-4d6c-8cbb-107c9f229290/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"update",
-						"1000",
+						"374669d8-4fd5-4d6c-8cbb-107c9f229290",
 						""
 					]
 				}
@@ -395,13 +405,13 @@
 					]
 				},
 				"url": {
-					"raw": "{{api_url_base}}/update/1002/",
+					"raw": "{{api_url_base}}/update/074669d8-4fd5-4d6c-8cbb-107c9f229290/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"update",
-						"1002",
+						"074669d8-4fd5-4d6c-8cbb-107c9f229290",
 						""
 					]
 				}
@@ -439,13 +449,13 @@
 					]
 				},
 				"url": {
-					"raw": "{{api_url_base}}/update/1002/",
+					"raw": "{{api_url_base}}/update/074669d8-4fd5-4d6c-8cbb-107c9f229290/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"update",
-						"1002",
+						"074669d8-4fd5-4d6c-8cbb-107c9f229290",
 						""
 					]
 				}
@@ -1512,6 +1522,11 @@
 					"mode": "formdata",
 					"formdata": [
 						{
+							"key": "id",
+							"value": "fbaf10d3-957c-4632-baf7-a47fe876a6f7",
+							"type": "text"
+						},
+						{
 							"key": "email",
 							"value": "test@gmail.com",
 							"type": "text"
@@ -1656,7 +1671,7 @@
 			"response": []
 		},
 		{
-			"name": "Social Media Signup Used Email",
+			"name": "BAD REQUEST Social Media Signup Used Email",
 			"event": [
 				{
 					"listen": "test",
@@ -2990,14 +3005,14 @@
 					"formdata": []
 				},
 				"url": {
-					"raw": "{{api_url_base}}/user/delete/2000/",
+					"raw": "{{api_url_base}}/user/delete/07544e52-e6dc-4fc9-af33-c80ee567f16e/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"user",
 						"delete",
-						"2000",
+						"07544e52-e6dc-4fc9-af33-c80ee567f16e",
 						""
 					]
 				}
@@ -3028,14 +3043,14 @@
 					"formdata": []
 				},
 				"url": {
-					"raw": "{{api_url_base}}/user/delete/1000/",
+					"raw": "{{api_url_base}}/user/delete/374669d8-4fd5-4d6c-8cbb-107c9f229290/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"user",
 						"delete",
-						"1000",
+						"374669d8-4fd5-4d6c-8cbb-107c9f229290",
 						""
 					]
 				}
@@ -3066,14 +3081,14 @@
 					"formdata": []
 				},
 				"url": {
-					"raw": "{{api_url_base}}/user/delete/1002/",
+					"raw": "{{api_url_base}}/user/delete/fbaf10d3-957c-4632-baf7-a47fe876a6f7/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"user",
 						"delete",
-						"1002",
+						"fbaf10d3-957c-4632-baf7-a47fe876a6f7",
 						""
 					]
 				}
@@ -3161,14 +3176,14 @@
 					"formdata": []
 				},
 				"url": {
-					"raw": "{{api_url_base}}/user/delete/1001/",
+					"raw": "{{api_url_base}}/user/delete/57544e52-e6dc-4fc9-af33-c80ee567f16e/",
 					"host": [
 						"{{api_url_base}}"
 					],
 					"path": [
 						"user",
 						"delete",
-						"1001",
+						"57544e52-e6dc-4fc9-af33-c80ee567f16e",
 						""
 					]
 				}

--- a/app_Backend/backend_server/postman/environments/Backend_Local.postman_environment.json
+++ b/app_Backend/backend_server/postman/environments/Backend_Local.postman_environment.json
@@ -10,13 +10,13 @@
 		},
 		{
 			"key": "host",
-			"value": "your.ip.here",
+			"value": "localhost",
 			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "port",
-			"value": "your.port.here",
+			"value": "8000",
 			"type": "default",
 			"enabled": true
 		},
@@ -28,6 +28,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2025-05-18T02:16:09.083Z",
-	"_postman_exported_using": "Postman/11.45.6"
+	"_postman_exported_at": "2025-08-03T08:33:36.544Z",
+	"_postman_exported_using": "Postman/11.56.2"
 }

--- a/app_Backend/backend_server/serializers.py
+++ b/app_Backend/backend_server/serializers.py
@@ -14,7 +14,9 @@ class UserSerializer(DocumentSerializer):
     class Meta:
         model = MyUser  
         fields = ['id','email', 'username', 'password', 'user_created', 'login_id', 'login_type','otp']
-        #extra_kwargs = {'password': {'write_only': True}} #don't return passwords whith user object
+        extra_kwargs = {
+            'id': {'required': False, 'read_only': False}  # allow manual ID setting
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -37,7 +39,10 @@ class SocialMediaUserSerializer(DocumentSerializer):
     otp = serializers.CharField(required=False) 
     class Meta:
         model = MyUser  
-        fields = ['id', 'email', 'username', 'password', 'user_created', 'login_id', 'login_type', 'otp']        
+        fields = ['id', 'email', 'username', 'password', 'user_created', 'login_id', 'login_type', 'otp']
+        extra_kwargs = {
+            'id': {'required': False, 'read_only': False}  # allow manual ID setting
+        }     
         #extra_kwargs = {'password': {'write_only': True}} #don't return passwords whith sm user object
 
     def __init__(self, *args, **kwargs):

--- a/app_Backend/backend_server/views.py
+++ b/app_Backend/backend_server/views.py
@@ -331,7 +331,6 @@ def auth_password(request, format=None):
         password = request.data.get('password')
 
         target_uuid = uuid.UUID(userId)
-        print(f'userId: {target_uuid}, password: {password}') #debug
         try:
             user = MyUser.objects.get(id=target_uuid) 
             if check_password(password, user.password):  #compares received password to stored hashed


### PR DESCRIPTION
MyUser model ID fields changed from Int to UUID in line with the rest of the project

Changes:
models.py:
- MyUser ID now uses UUIDv4 instead of Int
- Login_ID field now defaults to None
- Login_Type field now defaults to None
- MyUser model no longer allocates and increments IDs starting from 1000

Serializers.py:
- MyUser and SocialMedia Serializers now allow for assignment of IDs

views.py:
- updated views to use cast UUID ids to strings
- updated signup and sm-login views to allow for assignment of User IDs when in debug mode
- updated sm-login to strip and convert login_id/login_type to None
- imported MongoEngine queryset Q
- added additional try/catch blocks

POSTMAN TESTS:
- Updated tests to insert UUID IDs for Users identifiers in URLs and fields
- Updated backend Environment to use URL: localhost://8000

**FUTURE UPDATES:**
Some field name tidy up may be warranted when integrating with backend. Postman tests still failing in some semantic cases (the formatting of error messages) and should be updated further.