### PR TITLE
Create .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# API & data sources
+API_BASE_URL=https://example.com/api
+
+# MQTT broker for bike telemetry (WebSocket)
+MQTT_BROKER=wss://broker.hivemq.com:8884/mqtt
+
+# (optional) bridge service if used by team
+KAFKA_BRIDGE_URL=http://localhost:8080
+
+# feature toggles (true/false)
+USE_KAFKA=true


### PR DESCRIPTION
No secrets included. Adds .env.example to standardise local setup.
